### PR TITLE
updated code to accept processors -n option in the LSF config file

### DIFF
--- a/src/main/java/com/ibm/spectrumcomputing/cwl/exec/service/CWLLSFCommandServiceImpl.java
+++ b/src/main/java/com/ibm/spectrumcomputing/cwl/exec/service/CWLLSFCommandServiceImpl.java
@@ -157,6 +157,10 @@ final class CWLLSFCommandServiceImpl implements CWLCommandService {
                 commands.addAll(buildResCommand(resReq));
             }
         }
+	String processors = CWLExecConfUtil.getProcessors(flowExecConf, instance.getName());
+	if (processors != null && processors.length() > 0) {
+	    commands.addAll(Arrays.asList("-n", processors));
+	}		
         String app = CWLExecConfUtil.getApp(flowExecConf, instance.getName());
         if (app != null && app.length() > 0) {
             commands.addAll(Arrays.asList("-app", app));

--- a/src/main/java/com/ibm/spectrumcomputing/cwl/exec/util/CWLExecConfUtil.java
+++ b/src/main/java/com/ibm/spectrumcomputing/cwl/exec/util/CWLExecConfUtil.java
@@ -113,6 +113,34 @@ public final class CWLExecConfUtil {
     }
 
     /**
+     * Finds the number of processors configuration argument from a given FlowExecConf
+     * object by a CWL Workflow step name
+     *
+     * @param flowExecConf
+     *            A FlowExecConf object
+     * @param stepName
+     *            The name of a CWL workflow step
+     * @return If the configuration argument is not found, a null value will be
+     *         returned
+     */
+    public static String getProcessors(FlowExecConf flowExecConf, String stepName) {
+	String processors = null;
+	if (flowExecConf != null && stepName != null) {
+	    processors = flowExecConf.getProcessors();
+	    if (flowExecConf.getSteps() != null) {
+		StepExecConf stepExecConf = flowExecConf.getSteps().get(stepName);
+		if (stepExecConf != null) {
+		    String stepProcessors = stepExecConf.getProcessors();
+		    if (stepProcessors != null) {
+			processors = stepProcessors;
+		    }
+		}
+	    }
+	}
+	return processors;
+    }
+	    
+    /**
      * Finds the project configuration argument from a given FlowExecConf object
      * by a CWL Workflow step name
      * 

--- a/src/main/java/com/ibm/spectrumcomputing/cwl/model/conf/FlowExecConf.java
+++ b/src/main/java/com/ibm/spectrumcomputing/cwl/model/conf/FlowExecConf.java
@@ -26,6 +26,7 @@ public class FlowExecConf {
     private String queue;
     private String project;
     private boolean rerunnable;
+    private String processors;
     private PostFailureScript pfscript;
     private Map<String, StepExecConf> steps;
 
@@ -125,8 +126,25 @@ public class FlowExecConf {
     }
 
     /**
-     * Returns the step process configurations
+     * Returns the LSF processors (-n) option
      * 
+     * @return The LSF processors option
+     */
+    public String getProcessors() {
+        return processors;
+    }
+    /**
+     * Sets the LSF processors (-n) option
+     *
+     * @param processors
+     *        The LSF processors requirement option
+     */
+    public void setProcessors(String processors) {
+        this.processors = processors;
+    }
+    /**
+     * Returns the step process configurations
+     *
      * @return Step process configurations, the name of step is the key, the
      *         configuration of step is the value
      */

--- a/src/main/java/com/ibm/spectrumcomputing/cwl/model/conf/StepExecConf.java
+++ b/src/main/java/com/ibm/spectrumcomputing/cwl/model/conf/StepExecConf.java
@@ -25,6 +25,7 @@ public class StepExecConf {
     private boolean rerunnable;
     private String app;
     private String resource;
+    private String processors;
     private PostFailureScript pfscript;
 
     /**
@@ -121,7 +122,23 @@ public class StepExecConf {
     public void setRerunnable(boolean rerunnable) {
         this.rerunnable = rerunnable;
     }
-
+    /**
+     * Returns the LSF processors (-n) option
+     *
+     * @return the LSF processors option
+     */
+    public String getProcessors() {
+        return processors;
+    }
+    /**
+     * Sets the LSF processors (-n) option
+     *
+     * @param processors
+     *        The LSF processors requirement option
+     */
+    public void setProcessors(String processors) {
+        this.processors = processors;
+    }
     /**
      * Returns a post failure script configuration for a given step
      * 

--- a/src/main/java/com/ibm/spectrumcomputing/cwl/parser/CWLParser.java
+++ b/src/main/java/com/ibm/spectrumcomputing/cwl/parser/CWLParser.java
@@ -70,6 +70,7 @@ public final class CWLParser {
     private static final String RERUNNABLE = "rerunnable";
     private static final String PROJECT = "project";
     private static final String QUEUE = "queue";
+    private static final String PROCESSORS = "processors";
     private static final String POST_FAILURE_SCRIPT = "post-failure-script";
 
     /**
@@ -259,6 +260,7 @@ public final class CWLParser {
             JsonNode configNode = IOUtil.toJsonNode(confFile);
             flowExecConf.setProject(BaseParser.processStringField(PROJECT, configNode.get(PROJECT)));
             flowExecConf.setQueue(BaseParser.processStringField(QUEUE, configNode.get(QUEUE)));
+	    flowExecConf.setProcessors(BaseParser.processStringField(PROCESSORS, configNode.get(PROCESSORS)));
             Boolean rerunable = BaseParser.processBooleanField(RERUNNABLE, configNode.get(RERUNNABLE));
             flowExecConf.setRerunnable(rerunable != null ? rerunable.booleanValue() : false);
             flowExecConf.setApp(BaseParser.processStringField(APP, configNode.get(APP)));
@@ -278,6 +280,7 @@ public final class CWLParser {
                     stepExecConf.setProject(
                             BaseParser.processStringField(stepId + "#project", stepConfigNode.get(PROJECT)));
                     stepExecConf.setQueue(BaseParser.processStringField(stepId + "#queue", stepConfigNode.get(QUEUE)));
+		    stepExecConf.setProcessors(BaseParser.processStringField(stepId + "#processors", stepConfigNode.get(PROCESSORS)));
                     Boolean stepRerunnable = BaseParser.processBooleanField(stepId + "#rerunnable",
                             stepConfigNode.get(RERUNNABLE));
                     stepExecConf.setRerunnable(stepRerunnable != null ? stepRerunnable.booleanValue() : false);


### PR DESCRIPTION
This will allow users to pass the "processors" : "4" option to an lsf.conf file. An example conf for bwa:
```
[dkennetz@nodem103 prod cwlexec_test]$ more bwa-backtrack-LSF.json
{
    "queue": "standard",
    "project": "CWL_test",
    "res_req": "span[hosts=1]",
    "steps": {
        "bwaAln1": {
            "processors": "4",
            "res_req": "rusage[mem=6000]"
            },
        "bwaAln2": {
            "processors": "4",
            "res_req": "rusage[mem=6000]"
            },
        "bwaSampe": {
            "res_req": "rusage[mem=25000]"
            },
        "samtoolsView": {
            "res_req": "rusage[mem=10000]"
            },
        "picardSortSam": {
            "res_req": "rusage[mem=50000]"
            },
        "picardMarkDuplicates": {
            "res_req": "rusage[mem=50000]"
            },
        "samtoolsFlagstat": {
            "res_req": "rusage[mem=1000]"
            }
    }
}
```
Which will distribute jobs to one host with a multiple processors:
```
JOBID      USER    STAT  QUEUE      FROM_HOST   EXEC_HOST   JOB_NAME   SUBMIT_TIME
11111111   dkennet RUN   standard   nodem          4*node           *tq.gz.sai Jun 24 14:17
11111111   dkennet RUN   standard   nodem          4*node           *tq.gz.sai Jun 24 14:17
```
